### PR TITLE
fix inconsistent TabularInput keys bug

### DIFF
--- a/src/dowel/simple_outputs.py
+++ b/src/dowel/simple_outputs.py
@@ -59,6 +59,7 @@ class FileOutput(LogOutput, metaclass=abc.ABCMeta):
     def __init__(self, file_name, mode='w'):
         mkdir_p(os.path.dirname(file_name))
         # Open the log file in child class
+        self.mode = mode
         self._log_file = open(file_name, mode)
 
     def close(self):

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -38,19 +38,34 @@ class TestCsvOutput:
     def test_record_inconsistent(self):
         foo = 1
         bar = 10
+        new = 20
+        newer = 30
+
+        # row 0
         self.tabular.record('foo', foo)
         self.csv_output.record(self.tabular)
-        self.tabular.record('foo', foo * 2)
 
-        # this would create a new column and add an N/A entry to the first row
+        # row 1
+        self.tabular.record('foo', foo * 2)
+        # this would create 2 new columns and add empty entries to the first row
         self.tabular.record('bar', bar * 2)
+        self.tabular.record('new', new * 2)
+        self.csv_output.record(self.tabular)
+
+        # row 2
+        self.tabular.record('foo', foo * 3)
+        self.tabular.record('bar', bar * 3)
+        self.tabular.record('new', new * 3)
+        # this would add another column
+        self.tabular.record('newer', newer * 3)
         self.csv_output.record(self.tabular)
 
         self.csv_output.dump()
 
         correct = [
-            {'foo': str(foo), 'bar': str("N/A")},
-            {'foo': str(foo * 2), 'bar': str(bar * 2)},
+            {'foo': str(foo), 'bar': '', 'new': '', 'newer': ''},
+            {'foo': str(foo * 2), 'bar': str(bar * 2), 'new': str(new * 2), 'newer': ''},
+            {'foo': str(foo * 3), 'bar': str(bar * 3), 'new': str(new * 3), 'newer': str(newer * 3)},
         ]  # yapf: disable
         self.assert_csv_matches(correct)
 

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -41,19 +41,16 @@ class TestCsvOutput:
         self.tabular.record('foo', foo)
         self.csv_output.record(self.tabular)
         self.tabular.record('foo', foo * 2)
+
+        # this would create a new column and add an N/A entry to the first row
         self.tabular.record('bar', bar * 2)
-
-        with pytest.warns(CsvOutputWarning):
-            self.csv_output.record(self.tabular)
-
-        # this should not produce a warning, because we only warn once
         self.csv_output.record(self.tabular)
 
         self.csv_output.dump()
 
         correct = [
-            {'foo': str(foo)},
-            {'foo': str(foo * 2)},
+            {'foo': str(foo), 'bar': str("N/A")},
+            {'foo': str(foo * 2), 'bar': str(bar * 2)},
         ]  # yapf: disable
         self.assert_csv_matches(correct)
 


### PR DESCRIPTION
Issue [#45 Robust handling of inconsistent TabularInput keys](https://github.com/rlworkgroup/dowel/issues/45) is fixed by reading in currently logged csv data, add the new field, and write back to the original file. For previous entries of the new field, we mark it "N/A", indicating not applicable.

Main code change:
1. `src/dowel/csv_output.py` line 44-70: add implementation mentioned above.
2. The test method `test_record_inconsistent()` under `test/dowel/test_csv_output.py` line 45-53: modify test by deleting warning and change the correct output to reflect such fix.
3.`src/dowel/simple_outputs.py` line 62: record file access mode for reopening while handling inconsistent TabularInput keys.